### PR TITLE
Static CSS :: Introduces moduleInfo param on static css method

### DIFF
--- a/includes/modules/CustomCtaAllOptions/CustomCtaAllOptions.jsx
+++ b/includes/modules/CustomCtaAllOptions/CustomCtaAllOptions.jsx
@@ -11,9 +11,12 @@ class CustomCtaAllOptions extends Component {
    *
    * @since 1.0.0
    *
+   * @param {Object} props      Module attribute names and values.
+   * @param {Object} moduleInfo Module info.
+   *
    * @return array
    */
-  static css(props) {
+  static css(props, moduleInfo) {
     const utils         = window.ET_Builder.API.Utils;
     const additionalCss = [];
 


### PR DESCRIPTION
Introduces new `moduleInfo` as 2nd parameter of static css method contains module info such as:
- address
- order
- type
- order class name

This change is needed to adapt recent change on Divi `4.17.5`:
[3PS :: Custom Modules :: Pass additional module info on static css method](https://github.com/elegantthemes/Divi/issues/28202)
> Introduced module info as 2nd parameter of static css method of custom module component.